### PR TITLE
Remover opção DCTF de tarefas estaduais

### DIFF
--- a/Sistema
+++ b/Sistema
@@ -194,8 +194,6 @@
                                         <label class="form-check-label" for="obrigNfeEst">NF-e</label>
                                     </div>
                                     <div class="form-check">
-                                        <input class="form-check-input" type="checkbox" value="DCTF" id="obrigDctfEst">
-                                        <label class="form-check-label" for="obrigDctfEst">DCTF</label>
                                     </div>
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" value="EFD-Contribuições" id="obrigEfdContribEst">
@@ -434,6 +432,7 @@
 
         // ======= Inicialização
         document.addEventListener('DOMContentLoaded', ()=>{
+            migrarRemoverDctfEstaduais();
             migrarContabilidadeParaOutras();
             carregarEmpresas();
             // Empresa modal events
@@ -622,6 +621,46 @@
                                 if(obj['Federal|Contabilidade']){
                                     obj['Outras|Contabilidade'] = obj['Federal|Contabilidade'];
                                     delete obj['Federal|Contabilidade'];
+                                    localStorage.setItem(k, JSON.stringify(obj));
+                                }
+                            }catch{}
+                        }
+                    });
+                }catch{}
+                localStorage.setItem('empresas', JSON.stringify(empresas));
+            }
+        }
+
+        // Migração: remover 'DCTF' das obrigações Estaduais e limpar estados do checklist
+        function migrarRemoverDctfEstaduais(){
+            let alterou=false;
+            empresas = (empresas||[]).map(emp=>{
+                const estaduais = emp?.obrigacoesMensais?.estaduais||[];
+                if(estaduais.includes('DCTF')){
+                    const novasEstaduais = estaduais.filter(x=>x!=='DCTF');
+                    emp = {
+                        ...emp,
+                        obrigacoesMensais: {
+                            municipais: emp?.obrigacoesMensais?.municipais||[],
+                            estaduais: novasEstaduais,
+                            federais: emp?.obrigacoesMensais?.federais||[],
+                            outras: emp?.obrigacoesMensais?.outras||[]
+                        }
+                    };
+                    alterou=true;
+                }
+                return emp;
+            });
+            if(alterou){
+                // Remover possíveis chaves salvas no checklist para 'Estadual|DCTF'
+                try{
+                    const keys = Object.keys(localStorage);
+                    keys.forEach(k=>{
+                        if(k.startsWith('checklist_')){
+                            try{
+                                const obj = JSON.parse(localStorage.getItem(k)||'{}');
+                                if(Object.prototype.hasOwnProperty.call(obj, 'Estadual|DCTF')){
+                                    delete obj['Estadual|DCTF'];
                                     localStorage.setItem(k, JSON.stringify(obj));
                                 }
                             }catch{}


### PR DESCRIPTION
Remove the DCTF option from state obligations and add a migration to clean existing saved data and checklist states.

---
<a href="https://cursor.com/background-agent?bcId=bc-204f5c51-b6d7-4e3c-8dbf-be0e98b33dc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-204f5c51-b6d7-4e3c-8dbf-be0e98b33dc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

