### PR TITLE
Update digital certificate label to show expiry

### DIFF
--- a/Sistema
+++ b/Sistema
@@ -655,7 +655,7 @@
                                     <span class="badge bg-secondary regime-badge">${empresa.regimeCaixaCompetencia}</span>
                                 </p>
                                 <p class="card-text">
-                                    <small class="text-muted"><i class="fas fa-certificate me-1"></i> Cert. Digital: ${formatarData(empresa.certificadoDigital)}
+                                    <small class="text-muted"><i class="fas fa-certificate me-1"></i> Certi. Digital Vencimento: ${formatarData(empresa.certificadoDigital)}
                                     ${v && diff<=30 ? `<span class="badge bg-warning">Vence em ${diff} dias</span>`:''}</small>
                                 </p>
                                 <p class="card-text"><small class="text-muted"><i class="fas fa-user me-1"></i> Responsável: ${empresa.responsavel||'Não informado'}</small></p>
@@ -897,7 +897,7 @@
                                     <span class="badge bg-secondary regime-badge">${empresa.regimeCaixaCompetencia}</span>
                                 </p>
                                 <p class="card-text">
-                                    <small class="text-muted"><i class="fas fa-certificate me-1"></i> Cert. Digital: ${formatarData(empresa.certificadoDigital)}
+                                    <small class="text-muted"><i class="fas fa-certificate me-1"></i> Certi. Digital Vencimento: ${formatarData(empresa.certificadoDigital)}
                                     ${v && diff<=30 ? `<span class="badge bg-warning">Vence em ${diff} dias</span>`:''}</small>
                                 </p>
                                 <p class="card-text"><small class="text-muted"><i class="fas fa-user me-1"></i> Responsável: ${empresa.responsavel||'Não informado'}</small></p>


### PR DESCRIPTION
Update "Cert. Digital:" label to "Certi. Digital Vencimento:" for improved clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-b97aa79a-b6d1-4014-8483-488a836ba31a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b97aa79a-b6d1-4014-8483-488a836ba31a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

