### PR TITLE
Add accounting fiscal responsible names

### DIFF
--- a/Sistema
+++ b/Sistema
@@ -156,7 +156,15 @@
                             </div>
                             <div class="col-md-6">
                                 <label for="responsavel" class="form-label">Responsável Contábil/Fiscal</label>
-                                <input type="text" class="form-control" id="responsavel">
+                                <select class="form-select" id="responsavel">
+                                    <option value="">Selecione...</option>
+                                    <option value="Tyrone Rego">Tyrone Rego</option>
+                                    <option value="Vitoria Nogueira">Vitoria Nogueira</option>
+                                    <option value="Iva Palheta">Iva Palheta</option>
+                                    <option value="Amanda Fernandes">Amanda Fernandes</option>
+                                    <option value="João Rocha">João Rocha</option>
+                                    <option value="Thaynara Ferreira">Thaynara Ferreira</option>
+                                </select>
                             </div>
                         </div>
 


### PR DESCRIPTION
Replace the 'Responsável Contábil/Fiscal' text input with a select dropdown containing predefined names.

---
<a href="https://cursor.com/background-agent?bcId=bc-805a011b-0599-44f7-b998-3774cd63d7cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-805a011b-0599-44f7-b998-3774cd63d7cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

