### PR TITLE
Align accounting and non-accounting report options

### DIFF
--- a/Sistema
+++ b/Sistema
@@ -1605,8 +1605,7 @@
                                 <strong>${emp.nome}</strong> <small class=\"text-muted\">CNPJ: ${emp.cnpj||''}</small>
                                 <div class=\"small text-muted\">Responsável: ${emp.responsavel||'—'}</div>
                             </div>
-                            <span class=\"badge ${flagCom?'bg-primary':(flagSem?'bg-secondary':'bg-warning text-dark')}\">${classificacao}</span>
-                            <span class=\"badge ${classificacao==='Com Contabilidade' ? (conclusao==='Escriturado'?'bg-success':(conclusao==='Pendente'?'bg-warning text-dark':'bg-info')) : 'bg-light text-dark'}\">${conclusao}</span>
+                            <div class=\"d-flex align-items-center gap-2\">\n                                <span class=\"badge ${flagCom?'bg-primary':(flagSem?'bg-secondary':'bg-warning text-dark')}\">${classificacao}</span>\n                                <span class=\"badge ${classificacao==='Com Contabilidade' ? (conclusao==='Escriturado'?'bg-success':(conclusao==='Pendente'?'bg-warning text-dark':'bg-info')) : 'bg-light text-dark'}\">${conclusao}</span>\n                            </div>
                         </div>
                     </div>`;
             });


### PR DESCRIPTION
Align "Com Contabilidade" and status badges to the right in the Accounting Report.

The previous layout caused inconsistent alignment where one badge might appear in the middle and the other on the right. This change groups them in a flex container to ensure they are always aligned together on the right side of each report card.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5c67f4f-a974-49cf-943c-a1e95a7c03ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5c67f4f-a974-49cf-943c-a1e95a7c03ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

