### PR TITLE
Show four company columns on tab

### DIFF
--- a/Sistema
+++ b/Sistema
@@ -787,7 +787,7 @@
                 const diff = v ? Math.ceil((v - new Date())/(1000*60*60*24)) : Infinity;
                 const cardClass = v && diff<=30 ? 'vencimento-proximo':'';
                 wrap.innerHTML += `
-                    <div class="col-md-6 col-lg-4 mb-4">
+                    <div class="col-md-6 col-lg-3 mb-4">
                         <div class="card card-empresa ${cardClass}">
                             <div class="card-body">
                                 <h5 class="card-title">${empresa.nome}</h5>
@@ -1196,7 +1196,7 @@
                 const diff = v ? Math.ceil((v - new Date())/(1000*60*60*24)) : Infinity;
                 const cardClass = v && diff<=30 ? 'vencimento-proximo':'';
                 wrap.innerHTML += `
-                    <div class="col-md-6 col-lg-4 mb-4">
+                    <div class="col-md-6 col-lg-3 mb-4">
                         <div class="card card-empresa ${cardClass}">
                             <div class="card-body">
                                 <h5 class="card-title">${empresa.nome}</h5>


### PR DESCRIPTION
Adjust company card layout to display 4 columns on large screens in the 'Empresas Cadastradas' tab.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e42ba68-7d4f-4d9b-9424-6a12099af48c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e42ba68-7d4f-4d9b-9424-6a12099af48c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

